### PR TITLE
add Redis database number configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The server is configured via environment variables. See `server/README.md` for m
 | ------------------ | --------------------------------------------------------------------------- | -------------------- |
 | `LISTEN_PORT`      | The port on which the server will listen.                                   | `8080`               |
 | `REDIS_ADDR`       | The address of the Redis instance.                                          | `127.0.0.1:6379`     |
-| `REDIS_DB`         | Redis database number (0-15).                                               | `0`                  |
+| `REDIS_DB`         | Redis database number (0-15). **Note:** Redis Cluster only supports DB 0.   | `0`                  |
 | `DIFFICULTY`       | Number of leading zeros for the PoW hash. Higher is harder.                 | `4`                  |
 | `ALLOWED_ORIGINS`  | Comma-separated list of origins for CORS (e.g., `https://domain.com`).      | `*`                  |
 | `PRIVATE_KEY_PATH` | Path to store the Ed25519 private key. Will be created if it doesn't exist. | `./wicketkeeper.key` |

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ The server is configured via environment variables. See `server/README.md` for m
 | ------------------ | --------------------------------------------------------------------------- | -------------------- |
 | `LISTEN_PORT`      | The port on which the server will listen.                                   | `8080`               |
 | `REDIS_ADDR`       | The address of the Redis instance.                                          | `127.0.0.1:6379`     |
+| `REDIS_DB`         | Redis database number (0-15).                                               | `0`                  |
 | `DIFFICULTY`       | Number of leading zeros for the PoW hash. Higher is harder.                 | `4`                  |
 | `ALLOWED_ORIGINS`  | Comma-separated list of origins for CORS (e.g., `https://domain.com`).      | `*`                  |
 | `PRIVATE_KEY_PATH` | Path to store the Ed25519 private key. Will be created if it doesn't exist. | `./wicketkeeper.key` |

--- a/docs/components/backend-server.md
+++ b/docs/components/backend-server.md
@@ -77,7 +77,7 @@ The server is configured entirely through environment variables.
 | :----------------- | :-------------------------------------------------------------------------------------------------------------------------- | :------------------- |
 | `LISTEN_PORT`      | The port on which the server will listen for HTTP requests.                                                                 | `8080`               |
 | `REDIS_ADDR`       | The address (host:port) of the Redis instance.                                                                              | `127.0.0.1:6379`     |
-| `REDIS_DB`         | Redis database number (0-15).                                                                                               | `0`                  |
+| `REDIS_DB`         | Redis database number (0-15). **Note:** Redis Cluster only supports DB 0.                                                   | `0`                  |
 | `DIFFICULTY`       | The number of leading zero nibbles (4-bit chunks) for the PoW hash. A higher number increases the computational difficulty. | `4`                  |
 | `ALLOWED_ORIGINS`  | A comma-separated list of origins allowed for Cross-Origin Resource Sharing (CORS). Use `*` to allow all origins.           | `*`                  |
 | `PRIVATE_KEY_PATH` | Path to the file where the Ed25519 private key is stored. It will be created if it doesn't exist.                           | `./wicketkeeper.key` |

--- a/docs/components/backend-server.md
+++ b/docs/components/backend-server.md
@@ -77,6 +77,7 @@ The server is configured entirely through environment variables.
 | :----------------- | :-------------------------------------------------------------------------------------------------------------------------- | :------------------- |
 | `LISTEN_PORT`      | The port on which the server will listen for HTTP requests.                                                                 | `8080`               |
 | `REDIS_ADDR`       | The address (host:port) of the Redis instance.                                                                              | `127.0.0.1:6379`     |
+| `REDIS_DB`         | Redis database number (0-15).                                                                                               | `0`                  |
 | `DIFFICULTY`       | The number of leading zero nibbles (4-bit chunks) for the PoW hash. A higher number increases the computational difficulty. | `4`                  |
 | `ALLOWED_ORIGINS`  | A comma-separated list of origins allowed for Cross-Origin Resource Sharing (CORS). Use `*` to allow all origins.           | `*`                  |
 | `PRIVATE_KEY_PATH` | Path to the file where the Ed25519 private key is stored. It will be created if it doesn't exist.                           | `./wicketkeeper.key` |

--- a/server/README.md
+++ b/server/README.md
@@ -81,6 +81,7 @@ The server is configured using environment variables. You can create a `.env` fi
 | ------------------ | ---------------------------------------------------------------------------------------------------------- | -------------------- | ----------------------------------------------- |
 | `LISTEN_PORT`      | The port on which the server will listen for requests.                                                     | `8080`               | `8080`                                          |
 | `REDIS_ADDR`       | The address of the Redis instance.                                                                         | `127.0.0.1:6379`     | `localhost:6379`                                |
+| `REDIS_DB`         | Redis database number (0-15).                                                                              | `0`                  | `1`                                             |
 | `DIFFICULTY`       | The number of leading zeros required in the PoW hash. Higher is harder.                                    | `4`                  | `5`                                             |
 | `ALLOWED_ORIGINS`  | Comma-separated list of origins allowed for CORS. Use `*` for all. Supports wildcards like `*.domain.com`. | `*`                  | `https://myapp.com,https://*.staging.myapp.com` |
 | `PRIVATE_KEY_PATH` | Path to the file where the Ed25519 private key is stored. It will be created if it doesn't exist.          | `./wicketkeeper.key` | `/etc/secrets/wicketkeeper.key`                 |

--- a/server/README.md
+++ b/server/README.md
@@ -81,7 +81,7 @@ The server is configured using environment variables. You can create a `.env` fi
 | ------------------ | ---------------------------------------------------------------------------------------------------------- | -------------------- | ----------------------------------------------- |
 | `LISTEN_PORT`      | The port on which the server will listen for requests.                                                     | `8080`               | `8080`                                          |
 | `REDIS_ADDR`       | The address of the Redis instance.                                                                         | `127.0.0.1:6379`     | `localhost:6379`                                |
-| `REDIS_DB`         | Redis database number (0-15).                                                                              | `0`                  | `1`                                             |
+| `REDIS_DB`         | Redis database number (0-15). **Note:** Redis Cluster only supports DB 0.                                  | `0`                  | `1`                                             |
 | `DIFFICULTY`       | The number of leading zeros required in the PoW hash. Higher is harder.                                    | `4`                  | `5`                                             |
 | `ALLOWED_ORIGINS`  | Comma-separated list of origins allowed for CORS. Use `*` for all. Supports wildcards like `*.domain.com`. | `*`                  | `https://myapp.com,https://*.staging.myapp.com` |
 | `PRIVATE_KEY_PATH` | Path to the file where the Ed25519 private key is stored. It will be created if it doesn't exist.          | `./wicketkeeper.key` | `/etc/secrets/wicketkeeper.key`                 |

--- a/server/main.go
+++ b/server/main.go
@@ -124,7 +124,16 @@ func main() {
 		log.Printf("REDIS_ADDR not set, using default: %s", redisAddr)
 	}
 
-	srv, err := NewServer(difficulty, allowedOriginsList, privKey, pubKey, redisAddr)
+	redisDBStr := os.Getenv("REDIS_DB")
+	redisDB, err := strconv.Atoi(redisDBStr)
+	if err != nil || redisDB < 0 || redisDB > 15 {
+		redisDB = 0
+		log.Printf("REDIS_DB not set or invalid ('%s'), using default: %d", redisDBStr, redisDB)
+	} else {
+		log.Printf("REDIS_DB configured: %d", redisDB)
+	}
+
+	srv, err := NewServer(difficulty, allowedOriginsList, privKey, pubKey, redisAddr, redisDB)
 	if err != nil {
 		log.Fatalf("Failed to initialize server: %v", err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -20,9 +20,10 @@ type Server struct {
 	checkAddScript *redis.Script      // Lua script for atomically checking and adding CIDs to Bloom filters.
 }
 
-func NewServer(difficulty int, allowedOrigins []string, privKey ed25519.PrivateKey, pubKey ed25519.PublicKey, redisAddr string) (*Server, error) {
+func NewServer(difficulty int, allowedOrigins []string, privKey ed25519.PrivateKey, pubKey ed25519.PublicKey, redisAddr string, redisDB int) (*Server, error) {
 	rdb := redis.NewClient(&redis.Options{
 		Addr: redisAddr,
+		DB:   redisDB,
 	})
 
 	var checkAddScript = redis.NewScript(`
@@ -38,10 +39,10 @@ func NewServer(difficulty int, allowedOrigins []string, privKey ed25519.PrivateK
 	defer cancel()
 
 	if _, err := rdb.Ping(ctx).Result(); err != nil {
-		log.Printf("Could not connect to Redis at %s: %v", redisAddr, err)
-		return nil, fmt.Errorf("could not connect to Redis at %s: %w", redisAddr, err)
+		log.Printf("Could not connect to Redis at %s DB %d: %v", redisAddr, redisDB, err)
+		return nil, fmt.Errorf("could not connect to Redis at %s DB %d: %w", redisAddr, redisDB, err)
 	}
-	log.Printf("Successfully connected to Redis at %s.", redisAddr)
+	log.Printf("Successfully connected to Redis at %s DB %d.", redisAddr, redisDB)
 
 	_, err := rdb.Do(ctx, "BF.RESERVE", "test_bloom_support", 0.01, 1000, "NONSCALING").Result()
 	if err != nil {


### PR DESCRIPTION
feat: add Redis database number configuration support

- Add REDIS_DB environment variable to specify Redis database (0-15)
- Update server initialization to accept and use Redis DB parameter  
- Add Redis DB configuration to documentation and README
- Default to database 0 if REDIS_DB not specified or invalid
- Log the configured Redis DB on startup for transparency