### PR TITLE
ci: reproducible npm builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install npm dependencies and run script
         run: |
           cd client
-          npm install
+          npm ci
           npm run build:fast
           npm run build:slow
           mv dist/ ../server/static


### PR DESCRIPTION
I forked the repo to facilitate building a Docker image with a custom `CHALLENGE_URL`, and noticed the pipeline is using `npm install`.

I recommend changing this to `npm ci`, which builds directly from the package lockfile rather than `package.json`. Using `npm install` can cause errors with go-releaser if package.json gets modified from `npm install` since the git status has unstaged stages. Additionally, this ensures builds from CI are reproducible from what runs on developer's machines.

Some additional details here: https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable