### PR TITLE
fix: webpack should reference process.env.CHALLENGE_URL

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -4,7 +4,7 @@ const webpack = require("webpack");
 module.exports = (env = {}) => {
   const solverType = env.solver || "fast";
   const challengeUrl = JSON.stringify(
-    env.CHALLENGE_URL || "http://localhost:8080/v0/challenge"
+    process.env.CHALLENGE_URL || "http://localhost:8080/v0/challenge"
   );
 
   return {


### PR DESCRIPTION
When trying to follow the documentation of passing a custom `CHALLENGE_URL` to `npm build..`, I had issues with it not being respected, none of my built `fast.js` used my custom `CHALLENGE_URL`

Upon some research and testing it seems like webpack should be referencing `process.env.CHALLENGE_URL` to get a env variable from the command line, not `env.CHALLENGE_URL`.

from https://webpack.js.org/guides/environment-variables/

> webpack's environment variables are different from the [environment variables](https://en.wikipedia.org/wiki/Environment_variable) of operating system shells like bash and CMD.exe