### PR TITLE
Support the `BASE_PATH` environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,15 +162,15 @@ You can now navigate to **<http://localhost:8081>** in your browser to see the W
 
 The server is configured via environment variables. See `server/README.md` for more details.
 
-| Variable           | Description                                                                                              | Default                 |
-| ------------------ | -------------------------------------------------------------------------------------------------------- | ----------------------- |
-| `LISTEN_PORT`      | The port on which the server will listen.                                                                | `8080`                  |
-| `REDIS_ADDR`       | The address of the Redis instance.                                                                       | `127.0.0.1:6379`        |
-| `REDIS_DB`         | Redis database number (0-15). **Note:** Redis Cluster only supports DB 0.                                | `0`                     |
-| `DIFFICULTY`       | Number of leading zeros for the PoW hash. Higher is harder.                                              | `4`                     |
-| `ALLOWED_ORIGINS`  | Comma-separated list of origins for CORS (e.g., `https://domain.com`).                                   | `*`                     |
-| `ROOT_URL`         | Public base URL (scheme + host, optional path prefix) used by the client JS and to derive the base path. | `http://localhost:8080` |
-| `PRIVATE_KEY_PATH` | Path to store the Ed25519 private key. Will be created if it doesn't exist.                              | `./wicketkeeper.key`    |
+| Variable           | Description                                                                                                                                                                                            | Default              |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------- |
+| `LISTEN_PORT`      | The port on which the server will listen.                                                                                                                                                              | `8080`               |
+| `REDIS_ADDR`       | The address of the Redis instance.                                                                                                                                                                     | `127.0.0.1:6379`     |
+| `REDIS_DB`         | Redis database number (0-15). **Note:** Redis Cluster only supports DB 0.                                                                                                                              | `0`                  |
+| `DIFFICULTY`       | Number of leading zeros for the PoW hash. Higher is harder.                                                                                                                                            | `4`                  |
+| `ALLOWED_ORIGINS`  | Comma-separated list of origins for CORS (e.g., `https://domain.com`).                                                                                                                                 | `*`                  |
+| `BASE_PATH`        | Base path for the server. Note: For paths other than `/` you should use `data-challenge-url` when using the client. See [here](https://wicketkeeper.io/components/frontend-widget.html#configuration). | `/captcha`           |
+| `PRIVATE_KEY_PATH` | Path to store the Ed25519 private key. Will be created if it doesn't exist.                                                                                                                            | `./wicketkeeper.key` |
 
 **API Endpoints:**
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The server is configured via environment variables. See `server/README.md` for m
 | `REDIS_DB`         | Redis database number (0-15). **Note:** Redis Cluster only supports DB 0.                                                                                                                              | `0`                  |
 | `DIFFICULTY`       | Number of leading zeros for the PoW hash. Higher is harder.                                                                                                                                            | `4`                  |
 | `ALLOWED_ORIGINS`  | Comma-separated list of origins for CORS (e.g., `https://domain.com`).                                                                                                                                 | `*`                  |
-| `BASE_PATH`        | Base path for the server. Note: For paths other than `/` you should use `data-challenge-url` when using the client. See [here](https://wicketkeeper.io/components/frontend-widget.html#configuration). | `/captcha`           |
+| `BASE_PATH`        | Base path for the server. Note: For paths other than `/` you should use `data-challenge-url` when using the client. See [here](https://wicketkeeper.io/components/frontend-widget.html#configuration). | `/`           |
 | `PRIVATE_KEY_PATH` | Path to store the Ed25519 private key. Will be created if it doesn't exist.                                                                                                                            | `./wicketkeeper.key` |
 
 **API Endpoints:**

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,6 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - ROOT_URL=http://localhost:8080
       - LISTEN_PORT=8080
       - REDIS_ADDR=wicketkeeper-redis:6379
       - DIFFICULTY=4

--- a/docs/components/backend-server.md
+++ b/docs/components/backend-server.md
@@ -73,16 +73,16 @@ If you prefer to run the server directly without Docker:
 
 The server is configured entirely through environment variables.
 
-| Variable          | Description                                                                                                                 | Default                 |
-| :---------------- | :-------------------------------------------------------------------------------------------------------------------------- | :---------------------- |
-| `LISTEN_PORT`     | The port on which the server will listen for HTTP requests.                                                                 | `8080`                  |
-| `REDIS_ADDR`      | The address (host:port) of the Redis instance.                                                                              | `127.0.0.1:6379`        |
-| `REDIS_DB`        | Redis database number (0-15). **Note:** Redis Cluster only supports DB 0.                                                   | `0`                     |
-| `DIFFICULTY`      | The number of leading zero nibbles (4-bit chunks) for the PoW hash. A higher number increases the computational difficulty. | `4`                     |
-| `ALLOWED_ORIGINS` | A comma-separated list of origins allowed for Cross-Origin Resource Sharing (CORS). Use `*` to allow all origins.           | `*`                     |
-| `ROOT_URL`        | Public base URL (scheme + host, optional path prefix) used by the client JS and to derive the base path.                    | `http://localhost:8080` |
-| `PRIVATE_KEY_PATH` | Path to the file where the Ed25519 private key is stored. It will be created if it doesn't exist. | `./wicketkeeper.key` |
-| `CORS_DEBUG` | Set to `true` to enable verbose CORS debugging logs. | `false` |
+| Variable           | Description                                                                                                                                                                                            | Default              |
+| :----------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------- |
+| `LISTEN_PORT`      | The port on which the server will listen for HTTP requests.                                                                                                                                            | `8080`               |
+| `REDIS_ADDR`       | The address (host:port) of the Redis instance.                                                                                                                                                         | `127.0.0.1:6379`     |
+| `REDIS_DB`         | Redis database number (0-15). **Note:** Redis Cluster only supports DB 0.                                                                                                                              | `0`                  |
+| `DIFFICULTY`       | The number of leading zero nibbles (4-bit chunks) for the PoW hash. A higher number increases the computational difficulty.                                                                            | `4`                  |
+| `ALLOWED_ORIGINS`  | A comma-separated list of origins allowed for Cross-Origin Resource Sharing (CORS). Use `*` to allow all origins.                                                                                      | `*`                  |
+| `BASE_PATH`        | Base path for the server. Note: For paths other than `/` you should use `data-challenge-url` when using the client. See [here](https://wicketkeeper.io/components/frontend-widget.html#configuration). | `/`           |
+| `PRIVATE_KEY_PATH` | Path to the file where the Ed25519 private key is stored. It will be created if it doesn't exist.                                                                                                      | `./wicketkeeper.key` |
+| `CORS_DEBUG`       | Set to `true` to enable verbose CORS debugging logs.                                                                                                                                                   | `false`              |
 
 ### Example `.env` file for `docker-compose`
 

--- a/server/README.md
+++ b/server/README.md
@@ -77,15 +77,15 @@ This will start a Redis container with the Bloom filter module included.
 
 The server is configured using environment variables. You can create a `.env` file and use a tool like `godotenv` or export them directly in your shell.
 
-| Variable           | Description                                                                                                | Default                 | Example                                         |
-| ------------------ | ---------------------------------------------------------------------------------------------------------- | ----------------------- | ----------------------------------------------- |
-| `LISTEN_PORT`      | The port on which the server will listen for requests.                                                     | `8080`                  | `8080`                                          |
-| `REDIS_ADDR`       | The address of the Redis instance.                                                                         | `127.0.0.1:6379`        | `localhost:6379`                                |
-| `REDIS_DB`         | Redis database number (0-15). **Note:** Redis Cluster only supports DB 0.                                  | `0`                     | `1`                                             |
-| `DIFFICULTY`       | The number of leading zeros required in the PoW hash. Higher is harder.                                    | `4`                     | `5`                                             |
-| `ALLOWED_ORIGINS`  | Comma-separated list of origins allowed for CORS. Use `*` for all. Supports wildcards like `*.domain.com`. | `*`                     | `https://myapp.com,https://*.staging.myapp.com` |
-| `ROOT_URL`         | Public base URL (scheme + host, optional path prefix) used by the client JS and to derive the base path.   | `http://localhost:8080` | `https://myapp.com/captcha`                     |
-| `PRIVATE_KEY_PATH` | Path to the file where the Ed25519 private key is stored. It will be created if it doesn't exist.          | `./wicketkeeper.key`    | `/etc/secrets/wicketkeeper.key`                 |
+| Variable           | Description                                                                                                                                                                                            | Default              | Example                                         |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------- | ----------------------------------------------- |
+| `LISTEN_PORT`      | The port on which the server will listen for requests.                                                                                                                                                 | `8080`               | `8080`                                          |
+| `REDIS_ADDR`       | The address of the Redis instance.                                                                                                                                                                     | `127.0.0.1:6379`     | `localhost:6379`                                |
+| `REDIS_DB`         | Redis database number (0-15). **Note:** Redis Cluster only supports DB 0.                                                                                                                              | `0`                  | `1`                                             |
+| `DIFFICULTY`       | The number of leading zeros required in the PoW hash. Higher is harder.                                                                                                                                | `4`                  | `5`                                             |
+| `ALLOWED_ORIGINS`  | Comma-separated list of origins allowed for CORS. Use `*` for all. Supports wildcards like `*.domain.com`.                                                                                             | `*`                  | `https://myapp.com,https://*.staging.myapp.com` |
+| `BASE_PATH`        | Base path for the server. Note: For paths other than `/` you should use `data-challenge-url` when using the client. See [here](https://wicketkeeper.io/components/frontend-widget.html#configuration). | `/`                  | `/captcha`                                      |
+| `PRIVATE_KEY_PATH` | Path to the file where the Ed25519 private key is stored. It will be created if it doesn't exist.                                                                                                      | `./wicketkeeper.key` | `/etc/secrets/wicketkeeper.key`                 |
 
 **Example Shell Export:**
 

--- a/server/main.go
+++ b/server/main.go
@@ -141,14 +141,12 @@ func main() {
 	case "", "/":
 		basePath = ""
 		log.Printf("BASE_PATH configured: /")
-		log.Printf("Mounted at base path: /")
 	default:
 		if !strings.HasPrefix(basePath, "/") {
 			basePath = "/" + basePath
 		}
 		basePath = strings.TrimRight(basePath, "/")
 		log.Printf("BASE_PATH configured: %s", basePath)
-		log.Printf("Mounted at base path: %s", basePath)
 	}
 
 	srv, err := NewServer(difficulty, allowedOriginsList, privKey, pubKey, redisAddr, redisDB)
@@ -162,7 +160,7 @@ func main() {
 		}
 	}()
 
-	log.Printf("Captcha Service Public Key (hex): %s", hex.EncodeToString(pubKey))
+	log.Printf("wicketkeeper public key (hex): %s", hex.EncodeToString(pubKey))
 
 	sub := http.NewServeMux()
 	sub.HandleFunc("/v0/challenge", srv.BuildChallenge)

--- a/server/main.go
+++ b/server/main.go
@@ -10,11 +10,9 @@ import (
 	"io/fs"
 	"log"
 	"net/http"
-	"net/url"
 	"os"
 	"os/signal"
 	"path"
-	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -135,30 +133,24 @@ func main() {
 		log.Printf("REDIS_DB configured: %d", redisDB)
 	}
 
-	root := os.Getenv("ROOT_URL")
-	if root == "" {
-		root = "http://localhost:8080"
-	}
-
-	u, err := url.Parse(root)
-	if err != nil || u.Scheme == "" || u.Host == "" {
-		log.Fatalf("Invalid ROOT_URL: %q", root)
-	}
-
-	origin := u.Scheme + "://" + u.Host
-	basePath := strings.TrimRight(u.Path, "/")
-	if basePath == "/" {
+	// BASE_PATH is a path prefix only (e.g., "/captcha"). Empty or "/" mounts at root.
+	basePath := os.Getenv("BASE_PATH")
+	basePath = strings.TrimSpace(basePath)
+	switch basePath {
+	case "", "/":
 		basePath = ""
-	}
-	if basePath != "" && !strings.HasPrefix(basePath, "/") {
-		basePath = "/" + basePath
+	default:
+		if !strings.HasPrefix(basePath, "/") {
+			basePath = "/" + basePath
+		}
+		basePath = strings.TrimRight(basePath, "/")
 	}
 
-	log.Printf("ROOT_URL configured: %s", root)
-	log.Printf("Public origin: %s", origin)
 	if basePath == "" {
+		log.Printf("BASE_PATH configured: /")
 		log.Printf("Mounted at base path: /")
 	} else {
+		log.Printf("BASE_PATH configured: %s", basePath)
 		log.Printf("Mounted at base path: %s", basePath)
 	}
 
@@ -189,12 +181,6 @@ func main() {
 	allowed := append([]string{}, srv.allowedOrigins...)
 	if len(allowed) == 0 {
 		allowed = []string{"*"}
-	}
-	if !(len(allowed) == 1 && allowed[0] == "*") {
-		found := slices.Contains(allowed, origin)
-		if !found {
-			allowed = append(allowed, origin)
-		}
 	}
 
 	handler = cors.New(cors.Options{

--- a/server/main.go
+++ b/server/main.go
@@ -136,20 +136,17 @@ func main() {
 	// BASE_PATH is a path prefix only (e.g., "/captcha"). Empty or "/" mounts at root.
 	basePath := os.Getenv("BASE_PATH")
 	basePath = strings.TrimSpace(basePath)
+
 	switch basePath {
 	case "", "/":
 		basePath = ""
+		log.Printf("BASE_PATH configured: /")
+		log.Printf("Mounted at base path: /")
 	default:
 		if !strings.HasPrefix(basePath, "/") {
 			basePath = "/" + basePath
 		}
 		basePath = strings.TrimRight(basePath, "/")
-	}
-
-	if basePath == "" {
-		log.Printf("BASE_PATH configured: /")
-		log.Printf("Mounted at base path: /")
-	} else {
 		log.Printf("BASE_PATH configured: %s", basePath)
 		log.Printf("Mounted at base path: %s", basePath)
 	}
@@ -174,7 +171,7 @@ func main() {
 	sub.HandleFunc("/slow.js", serveJS)
 
 	var handler http.Handler = sub
-	if basePath != "" && basePath != "/" {
+	if basePath != "" {
 		handler = http.StripPrefix(basePath, sub)
 	}
 


### PR DESCRIPTION
## Changes

* **Configurable mount path (`BASE_PATH`)**


  * New environment variable `BASE_PATH` allows mounting the API and static JS under a path prefix (e.g., `/captcha`).
  * Implementation: routes are registered on a sub-mux (`sub`), and the top-level handler optionally wraps it with `http.StripPrefix(basePath, sub)`.
  * Logs the configured and effective mount path.


* **Removed `ROOT_URL`-based JS rewriting** 

  * Old `serveJS` replaced `http://localhost:8080` in JS when `ROOT_URL` was set.
  * New version **does not** rewrite JS at all (and drops the `bytes` import and replace logic).


## Endpoints (effective URLs)

* **Without a base path (default):**

  * `/v0/challenge`, `/v0/siteverify`, `/fast.js`, `/slow.js`
* **With `BASE_PATH=/captcha`:**

  * `/captcha/v0/challenge`, `/captcha/v0/siteverify`, `/captcha/fast.js`, `/captcha/slow.js`

## Environment variables

* **Added:** `BASE_PATH` (path prefix for mounting; empty or `/` mounts at root).
* **No longer used:** `ROOT_URL` for JS rewriting (behavior removed).


## Operational / Behavioral Impact

* **Subpath mounting is first-class** → Easier reverse-proxying and multi-app hosts. Requests not starting with `BASE_PATH` will receive a 404 (due to `StripPrefix` behavior).
* **Safer static-asset handling** → Only serves `fast.js` and `slow.js`.
* **Removed JS host substitution** → If the frontend relied on `ROOT_URL`-driven rewriting, it must now use relative URLs, a correct base path, or a different configuration mechanism (e.g., build-time injection).
* **CORS defaults are sturdier** if the server’s allowed list is empty.

## Migration Notes

1. If you previously depended on `ROOT_URL` rewriting inside `fast.js`/`slow.js`, switch to relative endpoints using [data-challenge-url](https://wicketkeeper.io/components/frontend-widget.html#configuration) or inject the correct origin/path at build time.
2. When deploying behind a reverse proxy under a subpath, set `BASE_PATH` (e.g., `/captcha`) and update client code to call URLs with that prefix.
3. Verify CORS behavior: if `ALLOWED_ORIGINS` resolves to empty, the service now safely falls back to `*` when constructing the CORS handler.
