### PR TITLE
Add health check endpoint

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -45,13 +45,11 @@ func serveJS(w http.ResponseWriter, r *http.Request) {
 }
 
 func serveHealthCheck(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-
-	_, err := w.Write([]byte("ok"))
+	_, err := fmt.Fprint(w, "ok")
 
 	if err != nil {
-		http.Error(w, "failed to write http response", http.StatusInternalServerError)
+		log.Printf("failed to write http response: %w", err.Error())
 	}
 }
 

--- a/server/main.go
+++ b/server/main.go
@@ -178,7 +178,7 @@ func main() {
 	sub.HandleFunc("/v0/siteverify", srv.VerifyChallenge)
 	sub.HandleFunc("/fast.js", serveJS)
 	sub.HandleFunc("/slow.js", serveJS)
-	sub.HandleFunc("/_health", serveHealthCheck)
+	sub.HandleFunc("/health", serveHealthCheck)
 
 	var handler http.Handler = sub
 	if basePath != "" {

--- a/server/main.go
+++ b/server/main.go
@@ -44,6 +44,17 @@ func serveJS(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func serveHealthCheck(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+
+	_, err := w.Write([]byte("ok"))
+
+	if err != nil {
+		http.Error(w, "failed to write http response", http.StatusInternalServerError)
+	}
+}
+
 func loadOrGeneratePrivateKey(filePath string) (ed25519.PrivateKey, ed25519.PublicKey, error) {
 	keyDataHex, err := os.ReadFile(filePath)
 	if err == nil {
@@ -167,6 +178,7 @@ func main() {
 	sub.HandleFunc("/v0/siteverify", srv.VerifyChallenge)
 	sub.HandleFunc("/fast.js", serveJS)
 	sub.HandleFunc("/slow.js", serveJS)
+	sub.HandleFunc("/_health", serveHealthCheck)
 
 	var handler http.Handler = sub
 	if basePath != "" {


### PR DESCRIPTION
Some supervisors (as Kubernetes) may need to make health check requests to the software to known whether it's working properly and/or ready to serve requests.

This PR adds a simple health check endpoint for this purpose.