### PR TITLE
ci: pass CHALLENGE_URL from repo setting to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,8 @@ jobs:
           npm run build:fast
           npm run build:slow
           mv dist/ ../server/static
+        env:
+          CHALLENGE_URL: ${{ vars.CHALLENGE_URL }}
 
       - name: Install go dependencies
         run: |


### PR DESCRIPTION
# Problem

Currently the challenge URL needs to be provided at build time for the client JS. Currently the binaries/OCI image need to be rebuilt with a local build process which while easy, isn't as simple as running a GitHub workflow.

# Solution

With this change, a forked repo can set a GitHub repository-level variable for their CHALLENGE_URL. This is then passed to NPM's environment to properly set the challenge URL.