### PR TITLE
feat: use ROOT_URL env var to set challenge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ The server is configured via environment variables. See `server/README.md` for m
 | `DIFFICULTY`       | Number of leading zeros for the PoW hash. Higher is harder.                                                                                                                                            | `4`                  |
 | `ALLOWED_ORIGINS`  | Comma-separated list of origins for CORS (e.g., `https://domain.com`).                                                                                                                                 | `*`                  |
 | `BASE_PATH`        | Base path for the server. Note: For paths other than `/` you should use `data-challenge-url` when using the client. See [here](https://wicketkeeper.io/components/frontend-widget.html#configuration). | `/`           |
+| `ROOT_URL`       | Protocol and host for the client JS to connect to.                                                                                                                                                     | `http://localhost:8080` |
 | `PRIVATE_KEY_PATH` | Path to store the Ed25519 private key. Will be created if it doesn't exist.                                                                                                                            | `./wicketkeeper.key` |
 
 **API Endpoints:**
@@ -198,5 +199,3 @@ The script automatically initializes any `div` with the class `.wicketkeeper`.
   <button type="submit">Submit</button>
 </form>
 ```
-
-The client can be configured with a custom challenge endpoint during the build step. See `client/README.md` for details.

--- a/client/README.md
+++ b/client/README.md
@@ -47,16 +47,6 @@ Wicketkeeper is designed to be a privacy-friendly and user-centric alternative t
       npm run build:slow
       ```
 
-### Configuring the Challenge URL
-
-The client needs to know where to fetch the PoW challenge. By default, it points to `http://localhost:8080/v0/challenge`. You should override this at build time with your own endpoint.
-
-Pass the `CHALLENGE_URL` environment variable to the build script:
-
-```bash
-CHALLENGE_URL='https://api.your-domain.com/captcha/challenge' npm run build:fast
-```
-
 ## Usage
 
 After building `dist/wicketkeeper.js`, include it in your HTML file and add the widget to your form.

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -5,7 +5,6 @@ import { solver } from "solver";
   "use strict";
 
   const DEFAULT_MESSAGE = "Verify you are human";
-  const DEFAULT_CHALLENGE_URL = CHALLENGE_URL;
 
   const $ = (sel, root) => (root || document).querySelector(sel);
 
@@ -30,10 +29,8 @@ import { solver } from "solver";
 
     const options = { inputName: "wicketkeeper_solution", ...opts };
     const endpoints = {
-      challenge: options.endpoints?.challenge || DEFAULT_CHALLENGE_URL,
+      challenge: "{{ .url }}/v0/challenge"
     };
-    if (!endpoints.challenge)
-      throw new Error("endpoints.challenge is required");
 
     container.setAttribute("role", "button");
     container.setAttribute("tabindex", "0");

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -3,9 +3,6 @@ const webpack = require("webpack");
 
 module.exports = (env = {}) => {
   const solverType = env.solver || "fast";
-  const challengeUrl = JSON.stringify(
-    process.env.CHALLENGE_URL || "http://localhost:8080/v0/challenge"
-  );
 
   return {
     mode: env.mode || "production",
@@ -38,10 +35,5 @@ module.exports = (env = {}) => {
         },
       ],
     },
-    plugins: [
-      new webpack.DefinePlugin({
-        CHALLENGE_URL: challengeUrl,
-      }),
-    ],
   };
 };

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -5,12 +5,17 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/subtle"
+	"embed"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/fs"
 	"log"
 	"net/http"
+	"path"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -24,6 +29,11 @@ const (
 	bloomErrorRate = 0.01               // Target false-positive rate for Bloom filters (1%).
 	bloomCapacity  = 500_000            // Expected number of unique CIDs per sliceDuration for Bloom filter sizing.
 )
+
+//go:embed static/*
+var assets embed.FS
+var FS, _ = fs.Sub(assets, "static")
+var templates = template.Must(template.ParseFS(FS, "*.js"))
 
 func bloomKey(t time.Time) string {
 	rounded := t.UTC().Truncate(sliceDuration)
@@ -244,4 +254,19 @@ func (s *Server) VerifyChallenge(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(resp)
+}
+
+func (s *Server) serveJS(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "public, max-age=2628000")
+	w.Header().Set("Content-Type", "application/javascript")
+
+	// After StripPrefix, r.URL.Path should be "/fast.js" or "/slow.js".
+	name := path.Base(r.URL.Path)
+	switch name {
+	case "fast.js", "slow.js":
+		io.WriteString(w, s.challengeJS[name])
+	default:
+		http.NotFound(w, r)
+		return
+	}
 }

--- a/server/main.go
+++ b/server/main.go
@@ -4,15 +4,12 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
-	"embed"
 	"encoding/hex"
 	"fmt"
-	"io/fs"
 	"log"
 	"net/http"
 	"os"
 	"os/signal"
-	"path"
 	"strconv"
 	"strings"
 	"syscall"
@@ -20,29 +17,6 @@ import (
 
 	"github.com/rs/cors"
 )
-
-//go:embed static/*
-var assets embed.FS
-var FS, _ = fs.Sub(assets, "static")
-
-func serveJS(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Cache-Control", "public, max-age=2628000")
-	w.Header().Set("Content-Type", "application/javascript")
-
-	// After StripPrefix, r.URL.Path should be "/fast.js" or "/slow.js".
-	name := path.Base(r.URL.Path)
-	switch name {
-	case "fast.js", "slow.js":
-		data, err := fs.ReadFile(FS, name)
-		if err != nil {
-			http.Error(w, "failed to read file", http.StatusInternalServerError)
-			return
-		}
-		_, _ = w.Write(data)
-	default:
-		http.NotFound(w, r)
-	}
-}
 
 func loadOrGeneratePrivateKey(filePath string) (ed25519.PrivateKey, ed25519.PublicKey, error) {
 	keyDataHex, err := os.ReadFile(filePath)
@@ -133,6 +107,12 @@ func main() {
 		log.Printf("REDIS_DB configured: %d", redisDB)
 	}
 
+	rootUrl := os.Getenv("ROOT_URL")
+	if rootUrl == "" {
+		rootUrl = "http://localhost:8080"
+		log.Printf("ROOT_URL not set, using default: %s", rootUrl)
+	}
+
 	// BASE_PATH is a path prefix only (e.g., "/captcha"). Empty or "/" mounts at root.
 	basePath := os.Getenv("BASE_PATH")
 	basePath = strings.TrimSpace(basePath)
@@ -149,7 +129,7 @@ func main() {
 		log.Printf("BASE_PATH configured: %s", basePath)
 	}
 
-	srv, err := NewServer(difficulty, allowedOriginsList, privKey, pubKey, redisAddr, redisDB)
+	srv, err := NewServer(difficulty, allowedOriginsList, privKey, pubKey, redisAddr, redisDB, rootUrl)
 	if err != nil {
 		log.Fatalf("Failed to initialize server: %v", err)
 	}
@@ -165,8 +145,8 @@ func main() {
 	sub := http.NewServeMux()
 	sub.HandleFunc("/v0/challenge", srv.BuildChallenge)
 	sub.HandleFunc("/v0/siteverify", srv.VerifyChallenge)
-	sub.HandleFunc("/fast.js", serveJS)
-	sub.HandleFunc("/slow.js", serveJS)
+	sub.HandleFunc("/fast.js", srv.serveJS)
+	sub.HandleFunc("/slow.js", srv.serveJS)
 
 	var handler http.Handler = sub
 	if basePath != "" {

--- a/server/server.go
+++ b/server/server.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
 	"fmt"
@@ -18,9 +19,10 @@ type Server struct {
 	allowedOrigins []string           // List of allowed origins for CORS.
 	redisClient    *redis.Client      // Redis client for storing challenge state.
 	checkAddScript *redis.Script      // Lua script for atomically checking and adding CIDs to Bloom filters.
+	challengeJS    map[string]string  // Map of challenge JS scripts for the client.
 }
 
-func NewServer(difficulty int, allowedOrigins []string, privKey ed25519.PrivateKey, pubKey ed25519.PublicKey, redisAddr string, redisDB int) (*Server, error) {
+func NewServer(difficulty int, allowedOrigins []string, privKey ed25519.PrivateKey, pubKey ed25519.PublicKey, redisAddr string, redisDB int, rootUrl string) (*Server, error) {
 	rdb := redis.NewClient(&redis.Options{
 		Addr: redisAddr,
 		DB:   redisDB,
@@ -55,6 +57,17 @@ func NewServer(difficulty int, allowedOrigins []string, privKey ed25519.PrivateK
 		rdb.Del(ctx, "test_bloom_support")
 	}
 
+	challengeJS := map[string]string{}
+	for _, f := range []string{"fast.js", "slow.js"} {
+		var b bytes.Buffer
+		data := map[string]string{"url": rootUrl}
+		err = templates.ExecuteTemplate(&b, f, data)
+		if err != nil {
+			return nil, fmt.Errorf("unable to render js template '%s': %w", f, err)
+		}
+		challengeJS[f] = b.String()
+	}
+
 	return &Server{
 		priv:           privKey,
 		pub:            pubKey,
@@ -62,6 +75,7 @@ func NewServer(difficulty int, allowedOrigins []string, privKey ed25519.PrivateK
 		allowedOrigins: allowedOrigins,
 		redisClient:    rdb,
 		checkAddScript: checkAddScript,
+		challengeJS:    challengeJS,
 	}, nil
 }
 


### PR DESCRIPTION
This PR addresses the feedback I shared in #29 about increasing the usability of the default docker image.

The client JS scripts will be generated/built into the docker image as a golang template file. Upon server startup, we render those script templates once, store them in the `Server` object, and write them into HTTP responses when their respective endpoints are requested.

As written, this is a breaking change, as it removes the ability to set the URL in the client JS build arguments. I made this decision for simplicity (set in a single way) but I can make it backwards compatible if desired.

Please share any feedback/questions about the overall approach, env variable name, etc, more than happy to address feedback!

I have this running live at https://captcha.pve.dev and is working properly.

Closes #29 